### PR TITLE
Apply Spotify-inspired styling and update contact page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,34 +1,67 @@
 body {
-    font-family: Arial, sans-serif;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin: 0;
     padding: 0;
     background-color: #121212;
     color: #fff;
 }
-.top-nav ul {
-    display: flex;
-    list-style: none;
-    background-color: #1db954;
-    padding: 10px;
-}
-.top-nav li {
-    margin-right: 20px;
-}
+
+/* old top-nav styles removed after navigation redesign */
 .side-nav {
-    width: 200px;
-    background-color: #000;
+    width: 220px;
+    background-color: #040404;
     padding-top: 20px;
     position: fixed;
     height: 100%;
 }
+
 .side-nav ul {
     list-style: none;
     padding: 0;
 }
+
 .side-nav li {
     padding: 10px 20px;
 }
+
+.side-nav a {
+    color: #b3b3b3;
+    text-decoration: none;
+}
+
+.side-nav a:hover {
+    color: #fff;
+}
+
 .content {
-    margin-left: 200px;
+    margin-left: 220px;
     padding: 20px;
+}
+
+.profile-img {
+    width: 150px;
+    border-radius: 50%;
+    margin-top: 20px;
+}
+
+.social-buttons {
+    margin-top: 20px;
+}
+
+.circle-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: #1db954;
+    color: #fff;
+    margin-right: 10px;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.circle-button:hover {
+    background-color: #1ed760;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,16 +7,6 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
-    <header>
-        <nav class="top-nav">
-            <ul>
-                <li><a href="{{ url_for('about') }}">About</a></li>
-                <li><a href="{{ url_for('projects') }}">Projects</a></li>
-                <li><a href="{{ url_for('resume') }}">Resume</a></li>
-                <li><a href="{{ url_for('contact') }}">Contact Me</a></li>
-            </ul>
-        </nav>
-    </header>
 
     <div class="spotify-layout">
         <aside class="side-nav">
@@ -25,6 +15,7 @@
                 <li><a href="{{ url_for('library') }}">Library</a></li>
                 <li><a href="{{ url_for('playlists') }}">My Playlists</a></li>
                 <li><a href="{{ url_for('resume') }}">Resume</a></li>
+                <li><a href="{{ url_for('contact') }}">Contact Me</a></li>
             </ul>
         </aside>
         <main class="content">

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,4 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Contact Me</h1>
+<h1>Aditi Patil</h1>
+<img src="{{ url_for('static', filename='images/profile.jpg') }}" alt="Aditi Patil" class="profile-img">
+<div class="social-buttons">
+    <a href="#" class="circle-button github">G</a>
+    <a href="#" class="circle-button linkedin">in</a>
+    <a href="mailto:#" class="circle-button email">@</a>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove top nav and keep only sidebar navigation
- add `Contact Me` link to sidebar
- restyle with Spotify colors and fonts
- overhaul the Contact page with name, image placeholder and social buttons

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684739159d80832ca1e021121ba0a2bc