### PR TITLE
Add simple bottom player bar

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,34 +1,52 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, url_for
+
+# Simple mapping of page names to placeholder cover images
+COVER_IMAGES = {
+    'Home': 'https://via.placeholder.com/64?text=Home',
+    'About': 'https://via.placeholder.com/64?text=About',
+    'Projects': 'https://via.placeholder.com/64?text=Projects',
+    'Resume': 'https://via.placeholder.com/64?text=Resume',
+    'Contact Me': 'https://via.placeholder.com/64?text=Contact',
+    'Library': 'https://via.placeholder.com/64?text=Library',
+    'My Playlists': 'https://via.placeholder.com/64?text=Playlists'
+}
 
 app = Flask(__name__)
 
 @app.route('/')
 def home():
-    return render_template('index.html')
+    return render_template('index.html', page_name='Home',
+                           cover_image=COVER_IMAGES['Home'])
 
 @app.route('/about')
 def about():
-    return render_template('about.html')
+    return render_template('about.html', page_name='About',
+                           cover_image=COVER_IMAGES['About'])
 
 @app.route('/projects')
 def projects():
-    return render_template('projects.html')
+    return render_template('projects.html', page_name='Projects',
+                           cover_image=COVER_IMAGES['Projects'])
 
 @app.route('/resume')
 def resume():
-    return render_template('resume.html')
+    return render_template('resume.html', page_name='Resume',
+                           cover_image=COVER_IMAGES['Resume'])
 
 @app.route('/contact')
 def contact():
-    return render_template('contact.html')
+    return render_template('contact.html', page_name='Contact Me',
+                           cover_image=COVER_IMAGES['Contact Me'])
 
 @app.route('/library')
 def library():
-    return render_template('library.html')
+    return render_template('library.html', page_name='Library',
+                           cover_image=COVER_IMAGES['Library'])
 
 @app.route('/playlists')
 def playlists():
-    return render_template('playlists.html')
+    return render_template('playlists.html', page_name='My Playlists',
+                           cover_image=COVER_IMAGES['My Playlists'])
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -36,6 +36,7 @@ body {
 .content {
     margin-left: 220px;
     padding: 20px;
+    padding-bottom: 100px; /* space for bottom player */
 }
 
 .profile-img {
@@ -64,4 +65,36 @@ body {
 
 .circle-button:hover {
     background-color: #1ed760;
+}
+
+/* Bottom player bar styles */
+.player-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 80px;
+    background-color: #181818;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    box-sizing: border-box;
+}
+
+.player-cover {
+    width: 64px;
+    height: 64px;
+}
+
+.play-button {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 28px;
+    cursor: pointer;
+}
+
+.player-right {
+    color: #fff;
 }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,1 +1,12 @@
-// Add custom JavaScript here
+document.addEventListener('DOMContentLoaded', function () {
+    var btn = document.getElementById('play-button');
+    if (btn) {
+        btn.addEventListener('click', function () {
+            if (btn.textContent === '▶') {
+                btn.textContent = '❚❚';
+            } else {
+                btn.textContent = '▶';
+            }
+        });
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,18 @@
         </main>
     </div>
 
+    <footer class="player-bar">
+        <div class="player-left">
+            <img src="{{ cover_image }}" alt="{{ page_name }} cover" class="player-cover">
+        </div>
+        <div class="player-center">
+            <button id="play-button" class="play-button">&#9654;</button>
+        </div>
+        <div class="player-right">
+            <span id="current-song">{{ page_name }}</span>
+        </div>
+    </footer>
+
     <script src="{{ url_for('static', filename='js/script.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create COVER_IMAGES mapping for placeholder images
- pass the current page name and cover image to templates in every route
- add a fixed bottom "player" bar showing the cover image and page name
- style the player bar and add play button behaviour in JS

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684739b68d88832ca8985a814ccd17b8