### PR TITLE
Improve music player and resume layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -95,31 +95,47 @@ body {
     height: 64px;
 }
 
-.play-button {
+.control-button {
     background: none;
     border: none;
     color: #fff;
     font-size: 28px;
     cursor: pointer;
+    margin: 0 5px;
+}
+.play-button {
+    /* inherits styles from .control-button */
 }
 
 .player-right {
     color: #fff;
 }
 
-/* Resume table styling */
-.resume-table {
-    width: 100%;
-    min-height: calc(100vh - 100px);
-    border-collapse: collapse;
+/* Resume page layout */
+.resume-section {
+    margin-bottom: 30px;
 }
-.resume-table th,
-.resume-table td {
-    border: 1px solid #282828;
-    padding: 10px;
+.resume-section h2 {
+    margin-bottom: 10px;
+    border-bottom: 1px solid #282828;
+    padding-bottom: 5px;
 }
-.resume-table th {
-    background-color: #181818;
+.resume-item {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 0;
+}
+.skills {
+    margin-top: 10px;
+}
+.skill-bubble {
+    display: inline-block;
+    background-color: #1db954;
+    color: #fff;
+    padding: 5px 12px;
+    border-radius: 20px;
+    margin: 5px;
+    font-size: 14px;
 }
 
 /* Card grid used by library and playlists pages */

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,11 @@
             <img src="{{ cover_image }}" alt="{{ page_name }} cover" class="player-cover">
         </div>
         <div class="player-center">
-            <button id="play-button" class="play-button">&#9654;</button>
+            <button class="control-button" id="shuffle-button">&#128256;</button>
+            <button class="control-button" id="rewind-button">&#9198;</button>
+            <button id="play-button" class="control-button play-button">&#9654;</button>
+            <button class="control-button" id="forward-button">&#9197;</button>
+            <button class="control-button" id="replay-button">&#128257;</button>
         </div>
         <div class="player-right">
             <span id="current-song">{{ page_name }}</span>

--- a/templates/resume.html
+++ b/templates/resume.html
@@ -1,22 +1,29 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Resume</h1>
-<table class="resume-table">
-    <tr>
-        <th>Section</th>
-        <th>Details</th>
-    </tr>
-    <tr>
-        <td>Education</td>
-        <td><!-- fill in your education details --></td>
-    </tr>
-    <tr>
-        <td>Experience</td>
-        <td><!-- fill in your work experience --></td>
-    </tr>
-    <tr>
-        <td>Skills</td>
-        <td><!-- list your skills here --></td>
-    </tr>
-</table>
+
+<div class="resume-section">
+    <h2>Education</h2>
+    <div class="resume-item">
+        <span class="resume-left">School</span>
+        <span class="resume-right">Years attended</span>
+    </div>
+</div>
+
+<div class="resume-section">
+    <h2>Experience</h2>
+    <div class="resume-item">
+        <span class="resume-left">Job #1</span>
+        <span class="resume-right">2020-present</span>
+    </div>
+</div>
+
+<div class="resume-section">
+    <h2>Skills</h2>
+    <div class="skills">
+        <span class="skill-bubble">Python</span>
+        <span class="skill-bubble">Flask</span>
+        <span class="skill-bubble">HTML</span>
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add shuffle, rewind, forward and replay controls to the bottom player
- restyle resume page without table and use green skill bubbles
- add CSS for new player controls and resume layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848721ecd48832c9d6e600919fa83c2